### PR TITLE
Use invariant culture for parsing double values

### DIFF
--- a/tools/ColorTool/ColorTool/XmlSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/XmlSchemeParser.cs
@@ -3,6 +3,7 @@
 // Licensed under the terms described in the LICENSE file in the root of this project.
 //
 using System;
+using System.Globalization;
 using System.Xml;
 using static ColorTool.ConsoleAPI;
 
@@ -45,15 +46,15 @@ namespace ColorTool
                 {
                     if (c.InnerText == RED_KEY)
                     {
-                        r = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText));
+                        r = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText, CultureInfo.InvariantCulture));
                     }
                     else if (c.InnerText == GREEN_KEY)
                     {
-                        g = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText));
+                        g = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText, CultureInfo.InvariantCulture));
                     }
                     else if (c.InnerText == BLUE_KEY)
                     {
-                        b = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText));
+                        b = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText, CultureInfo.InvariantCulture));
                     }
                     else
                     {


### PR DESCRIPTION
iTerm2 color schemes could not be parsed when using a non-english locale. This fixes the issue.