### PR TITLE
Default to msbuild.exe on PATH if found

### DIFF
--- a/tools/ColorTool/build.bat
+++ b/tools/ColorTool/build.bat
@@ -2,6 +2,10 @@
 
 rem Add path to MSBuild Binaries
 set MSBUILD=()
+for /f "usebackq tokens=*" %%f in (`where.exe msbuild.exe 2^>nul`) do (
+    set MSBUILD="%%~ff"
+    goto :FOUND_MSBUILD
+)
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe" (
     set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe"
     goto :FOUND_MSBUILD


### PR DESCRIPTION
If msbuild is already on PATH, use that one instead of searching through known install locations. This way, if a user or contributor has already added msbuild to PATH (e.g. by running from a "Developer Command Prompt" for VS 2015 or 2017), the build uses the expected version of the tools.