### PR TITLE
Allow program to work in non-English languages

### DIFF
--- a/tools/ColorTool/ColorTool/XmlSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/XmlSchemeParser.cs
@@ -3,6 +3,7 @@
 // Licensed under the terms described in the LICENSE file in the root of this project.
 //
 using System;
+using System.Diagnostics;
 using System.Xml;
 using static ColorTool.ConsoleAPI;
 
@@ -41,24 +42,19 @@ namespace ColorTool
 
             foreach (XmlNode c in components.ChildNodes)
             {
-                if (c.Name == "key")
+                if (c.Name != "key") continue;
+                Debug.Assert(c.NextSibling != null, "c.NextSibling != null");
+                if (c.InnerText == RED_KEY)
                 {
-                    if (c.InnerText == RED_KEY)
-                    {
-                        r = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText));
-                    }
-                    else if (c.InnerText == GREEN_KEY)
-                    {
-                        g = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText));
-                    }
-                    else if (c.InnerText == BLUE_KEY)
-                    {
-                        b = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText));
-                    }
-                    else
-                    {
-                        continue;
-                    }
+                    r = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText));
+                }
+                else if (c.InnerText == GREEN_KEY)
+                {
+                    g = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText));
+                }
+                else if (c.InnerText == BLUE_KEY)
+                {
+                    b = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText));
                 }
             }
             if (r < 0 || g < 0 || b < 0)

--- a/tools/ColorTool/ColorTool/XmlSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/XmlSchemeParser.cs
@@ -4,6 +4,7 @@
 //
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Xml;
 using static ColorTool.ConsoleAPI;
 
@@ -46,15 +47,15 @@ namespace ColorTool
                 Debug.Assert(c.NextSibling != null, "c.NextSibling != null");
                 if (c.InnerText == RED_KEY)
                 {
-                    r = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText));
+                    r = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText, CultureInfo.InvariantCulture));
                 }
                 else if (c.InnerText == GREEN_KEY)
                 {
-                    g = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText));
+                    g = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText, CultureInfo.InvariantCulture));
                 }
                 else if (c.InnerText == BLUE_KEY)
                 {
-                    b = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText));
+                    b = (int)(255 * Convert.ToDouble(c.NextSibling.InnerText, CultureInfo.InvariantCulture));
                 }
             }
             if (r < 0 || g < 0 || b < 0)


### PR DESCRIPTION
Parsing a number should almost always contain the culture that the parsing should happen, otherwise local culture may break it. In the case of a standardized format (e.g. the itermcolor plist XML standard), the numbers use "." as the decimal separator, so the proper culture is the InvariantCulture. This is by definition the same as en_US, but it's more suited for parsing standardized strings such as this.