### PR TITLE
Add build badge for color tool master.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Please attempt to avoid filing duplicates of open or closed items when possible.
 
 ## Build Status
 
-
+Project|Build Status
 ---|---
 tools/ColorTool|![](https://microsoft.visualstudio.com/_apis/public/build/definitions/c93e867a-8815-43c1-92c4-e7dd5404f1e1/17023/badge)

--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ Please attempt to avoid filing duplicates of open or closed items when possible.
 
 ## Build Status
 
-|---|---|
-|tools/ColorTool|![](https://microsoft.visualstudio.com/_apis/public/build/definitions/c93e867a-8815-43c1-92c4-e7dd5404f1e1/17023/badge)|
+
+---|---
+tools/ColorTool|![](https://microsoft.visualstudio.com/_apis/public/build/definitions/c93e867a-8815-43c1-92c4-e7dd5404f1e1/17023/badge)

--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ Here you'll find assorted console tools in the `tools/` directory, such as the
 
 We will be monitoring and responding to issues as best we can. 
 Please attempt to avoid filing duplicates of open or closed items when possible.
+
+## Build Status
+
+|---|---|
+|tools/ColorTool|![](https://microsoft.visualstudio.com/_apis/public/build/definitions/c93e867a-8815-43c1-92c4-e7dd5404f1e1/17023/badge)|


### PR DESCRIPTION
This adds a badge for the master branch line CI of colortool.
