### PR TITLE
ColorTool: Restore old console colors after printing the color table

### DIFF
--- a/tools/ColorTool/ColorTool/Program.cs
+++ b/tools/ColorTool/ColorTool/Program.cs
@@ -170,6 +170,10 @@ namespace ColorTool
 
             }
             Console.Write("\n");
+
+            // Reset foreground and background colors
+            Console.ForegroundColor = currentForeground;
+            Console.BackgroundColor = currentBackground;
         }
 
         static bool SetProperties(uint[] colorTable)


### PR DESCRIPTION
Unfortunately, when you run `.\colortool.exe --current`, you might notice that the color of the prompt printed after the program finishes is slightly different from what it was before you ran the program.

This changelist fixes the issue by restoring the old console colors after the program finishes printing the color table.

Testing: manual