### PR TITLE
ColorTool: Fix the included all.bat batch file

### DIFF
--- a/tools/ColorTool/all.bat
+++ b/tools/ColorTool/all.bat
@@ -9,6 +9,6 @@ rem     All of the previously viewed tables will display the current scheme's co
 
 for %%i in (schemes\*) do (
     echo %%i
-    ct.exe "%%i"
+    .\colortool.exe "%%i"
     pause
 )


### PR DESCRIPTION
all.bat doesn't work if you use build.bat to build the program, as all.bat looks for ct.exe rather than colortool.exe. Fortunately, fixing the batch file is almost as easy as working around its bug manually.