### PR TITLE
Add a switch for exporting settings

### DIFF
--- a/tools/ColorTool/ColorTool/IniSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/IniSchemeParser.cs
@@ -17,7 +17,7 @@ namespace ColorTool
         private static extern int GetPrivateProfileString(string section, string key, string def, StringBuilder retVal, int size, string filePath);
 
         // These are in Windows Color table order - BRG, not RGB. 
-        static string[] COLOR_NAMES = {
+        public static string[] COLOR_NAMES = {
             "DARK_BLACK",
             "DARK_BLUE",
             "DARK_GREEN",

--- a/tools/ColorTool/ColorTool/Program.cs
+++ b/tools/ColorTool/ColorTool/Program.cs
@@ -240,7 +240,7 @@ namespace ColorTool
             }
             else
             {
-                Console.WriteLine("Failed to get conosle information.");
+                Console.WriteLine("Failed to get console information.");
             }
             return success;
         }

--- a/tools/ColorTool/ColorTool/Resources.Designer.cs
+++ b/tools/ColorTool/ColorTool/Resources.Designer.cs
@@ -99,6 +99,15 @@ namespace ColorTool {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Usage: colortool -o &lt;filename&gt;.
+        /// </summary>
+        public static string OutputUsage {
+            get {
+                return ResourceManager.GetString("OutputUsage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not find or load &quot;{0}&quot;.
         /// </summary>
         public static string SchemeNotFound {

--- a/tools/ColorTool/ColorTool/Resources.resx
+++ b/tools/ColorTool/ColorTool/Resources.resx
@@ -131,6 +131,9 @@
   <data name="InvalidNumberOfColors" xml:space="preserve">
     <value>Invalid scheme - did not find 16 colors</value>
   </data>
+  <data name="OutputUsage" xml:space="preserve">
+    <value>Usage: colortool -o &lt;filename&gt;</value>
+  </data>
   <data name="SchemeNotFound" xml:space="preserve">
     <value>Could not find or load "{0}"</value>
   </data>
@@ -151,7 +154,9 @@ Options:
     -q, --quiet    : Don't print the color table after applying
     -d, --defaults : Apply the scheme to only the defaults in the registry
     -b, --both     : Apply the scheme to both the current console and the defaults.
-    -v, --version  : Display the version number</value>
+    -v, --version  : Display the version number
+    -o, --output &lt;filename&gt; : output the current color table to an file (in .ini format)
+</value>
   </data>
   <data name="WroteToDefaults" xml:space="preserve">
     <value>Wrote selected scheme to the defaults.</value>


### PR DESCRIPTION
  As suggested by #6. `colortool -o <filename>` will write the current properties to `<filename>`, in ini file format.