### PR TITLE
colortool: add support for fg/bg color slot designation, and color approximation

### DIFF
--- a/tools/ColorTool/ColorTool/ColorScheme.cs
+++ b/tools/ColorTool/ColorTool/ColorScheme.cs
@@ -1,0 +1,83 @@
+﻿//
+//    Copyright (C) Microsoft.  All rights reserved.
+// Licensed under the terms described in the LICENSE file in the root of this project.
+//
+
+using System;
+using System.Linq;
+
+namespace ColorTool
+{
+    public class ColorScheme
+    {
+        public uint[] colorTable = null;
+        public uint? foreground = null;
+        public uint? background = null;
+
+        public int CalculateIndex(uint value) =>
+            colorTable.Select((color, idx) => Tuple.Create(color, idx))
+                      .OrderBy(Difference(value))
+                      .First().Item2;
+
+        private static Func<Tuple<uint, int>, double> Difference(uint c1) =>
+        // heuristic 1: nearest neighbor in RGB space
+        // tup => Distance(RGB(c1), RGB(tup.Item1));
+        // heuristic 2: nearest neighbor in RGB space
+            tup => Distance(HSV(c1), HSV(tup.Item1));
+
+        private static double Distance(uint[] c1c, uint[] c2c)
+            => Math.Sqrt(c1c.Zip(c2c, (a, b) => Math.Pow((int)a - (int)b, 2)).Sum());
+
+        internal static uint[] RGB(uint c) => new[] { c & 0xFF, (c >> 8) & 0xFF, (c >> 16) & 0xFF };
+
+        internal static uint[] HSV(uint c)
+        {
+            var rgb = RGB(c).Select(_ => (int)_).ToArray();
+            int max = rgb.Max();
+            int min = rgb.Min();
+
+            int d = max - min;
+            int h = 0;
+            int s = (int)(255 * ((max == 0) ? 0 : d / (double)max));
+            int v = max;
+
+            if (d != 0)
+            {
+                double dh;
+                if (rgb[0] == max) dh = ((rgb[1] - rgb[2]) / (double)d);
+                else if (rgb[1] == max) dh = 2.0 + ((rgb[2] - rgb[0]) / (double)d);
+                else /* if (rgb[2] == max) */ dh = 4.0 + ((rgb[0] - rgb[1]) / (double)d);
+                dh *= 60;
+                if (dh < 0) dh += 360.0;
+                h = (int)(dh * 255.0 / 360.0);
+            }
+
+            return new[] { (uint)h, (uint)s, (uint)v };
+        }
+
+        internal void Dump()
+        {
+            Action<string, uint> _dump = (str, c) =>
+            {
+                var rgb = RGB(c);
+                var hsv = HSV(c);
+                Console.WriteLine($"{str} =\tRGB({rgb[0]}, {rgb[1]}, {rgb[2]}),\tHSV({hsv[0]}, {hsv[1]}, {hsv[2]})");
+            };
+
+            for (int i = 0; i < 16; ++i)
+            {
+                _dump($"Color[{i}]", colorTable[i]);
+            }
+
+            if (foreground != null)
+            {
+                _dump("FG       ", foreground.Value);
+            }
+
+            if (background != null)
+            {
+                _dump("BG       ", background.Value);
+            }
+        }
+    }
+}

--- a/tools/ColorTool/ColorTool/ColorScheme.cs
+++ b/tools/ColorTool/ColorTool/ColorScheme.cs
@@ -23,7 +23,18 @@ namespace ColorTool
         // heuristic 1: nearest neighbor in RGB space
         // tup => Distance(RGB(c1), RGB(tup.Item1));
         // heuristic 2: nearest neighbor in RGB space
-            tup => Distance(HSV(c1), HSV(tup.Item1));
+        // tup => Distance(HSV(c1), HSV(tup.Item1));
+        // heuristic 3: weighted RGB L2 distance
+           tup => WeightedRGBSimilarity(c1, tup.Item1);
+
+        private static double WeightedRGBSimilarity(uint c1, uint c2)
+        {
+            var rgb1 = RGB(c1);
+            var rgb2 = RGB(c2);
+            var dist = rgb1.Zip(rgb2, (a, b) => Math.Pow((int)a - (int)b, 2)).ToArray();
+            var rbar = (rgb1[0] + rgb1[0]) / 2.0;
+            return Math.Sqrt(dist[0] * (2 + rbar / 256.0) + dist[1] * 4 + dist[2] * (2 + (255 - rbar) / 256.0));
+        }
 
         private static double Distance(uint[] c1c, uint[] c2c)
             => Math.Sqrt(c1c.Zip(c2c, (a, b) => Math.Pow((int)a - (int)b, 2)).Sum());

--- a/tools/ColorTool/ColorTool/ColorTool.csproj
+++ b/tools/ColorTool/ColorTool/ColorTool.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ColorScheme.cs" />
     <Compile Include="ConsoleAPI.cs" />
     <Compile Include="IniSchemeParser.cs" />
     <Compile Include="ISchemeParser.cs" />

--- a/tools/ColorTool/ColorTool/ConsoleAPI.cs
+++ b/tools/ColorTool/ColorTool/ConsoleAPI.cs
@@ -32,7 +32,7 @@ namespace ColorTool
             public uint cbSize;
             public COORD dwSize;
             public COORD dwCursorPosition;
-            public short wAttributes;
+            public ushort wAttributes;
             public SMALL_RECT srWindow;
             public COORD dwMaximumWindowSize;
 
@@ -56,6 +56,7 @@ namespace ColorTool
 
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern bool SetConsoleScreenBufferInfoEx(IntPtr ConsoleOutput, ref CONSOLE_SCREEN_BUFFER_INFO_EX ConsoleScreenBufferInfoEx);
+
         ////////////////////////////////////////////////////////////////////////
 
         public static uint RGB(int r, int g, int b)

--- a/tools/ColorTool/ColorTool/ISchemeParser.cs
+++ b/tools/ColorTool/ColorTool/ISchemeParser.cs
@@ -7,6 +7,6 @@ namespace ColorTool
 {
     interface ISchemeParser
     {
-        uint[] ParseScheme(string schemeName);
+        ColorScheme ParseScheme(string schemeName);
     }
 }

--- a/tools/ColorTool/ColorTool/IniSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/IniSchemeParser.cs
@@ -104,7 +104,7 @@ namespace ColorTool
             return null;
         }
 
-        public uint[] ParseScheme(string schemeName)
+        public ColorScheme ParseScheme(string schemeName)
         {
             bool success = true;
 
@@ -147,7 +147,7 @@ namespace ColorTool
                 }
             }
 
-            return colorTable;
+            return new ColorScheme { colorTable = colorTable };
         }
     }
 }

--- a/tools/ColorTool/ColorTool/XmlSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/XmlSchemeParser.cs
@@ -4,6 +4,8 @@
 //
 using System;
 using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Xml;
 using static ColorTool.ConsoleAPI;
 
@@ -30,6 +32,8 @@ namespace ColorTool
             "Ansi 11 Color", // BRIGHT_YELLOW
             "Ansi 15 Color" // BRIGHT_WHITE
         };
+        static string FG_KEY = "Foreground Color";
+        static string BG_KEY = "Background Color";
         static string RED_KEY = "Red Component";
         static string GREEN_KEY = "Green Component";
         static string BLUE_KEY = "Blue Component";
@@ -121,7 +125,7 @@ namespace ColorTool
         }
 
 
-        public uint[] ParseScheme(string schemeName)
+        public ColorScheme ParseScheme(string schemeName)
         {
             XmlDocument xmlDoc = loadXmlScheme(schemeName); // Create an XML document object
             if (xmlDoc == null) return null;
@@ -129,39 +133,20 @@ namespace ColorTool
             XmlNodeList children = root.ChildNodes;
 
             uint[] colorTable = new uint[COLOR_TABLE_SIZE];
+            uint? fgColor = null, bgColor = null;
             int colorsFound = 0;
             bool success = false;
-            foreach (XmlNode tableEntry in children)
+            foreach (var tableEntry in children.OfType<XmlNode>().Where(_ => _.Name == "key"))
             {
-                if (tableEntry.Name == "key")
-                {
-                    int index = -1;
-                    for (int i = 0; i < COLOR_TABLE_SIZE; i++)
-                    {
-                        if (PLIST_COLOR_NAMES[i] == tableEntry.InnerText)
-                        {
-                            index = i;
-                            break;
-                        }
-                    }
-                    if (index == -1)
-                    {
-                        continue;
-                    }
-                    uint rgb = 0; ;
-                    XmlNode components = tableEntry.NextSibling;
-                    success = parseRgbFromXml(components, ref rgb);
-                    if (!success)
-                    {
-                        break;
-                    }
-                    else
-                    {
-                        colorTable[index] = rgb;
-                        colorsFound++;
-                    }
-                }
-
+                uint rgb = 0;
+                int index = -1;
+                XmlNode components = tableEntry.NextSibling;
+                success = parseRgbFromXml(components, ref rgb);
+                if (!success) { break; }
+                else if (tableEntry.InnerText == FG_KEY) { fgColor = rgb; }
+                else if (tableEntry.InnerText == BG_KEY) { bgColor = rgb; }
+                else if (-1 != (index = Array.IndexOf(PLIST_COLOR_NAMES, tableEntry.InnerText)))
+                { colorTable[index] = rgb; colorsFound++; }
             }
             if (colorsFound < COLOR_TABLE_SIZE)
             {
@@ -172,8 +157,8 @@ namespace ColorTool
             {
                 return null;
             }
-            return colorTable;
 
+            return new ColorScheme { colorTable = colorTable, foreground = fgColor, background = bgColor };
         }
     }
 }


### PR DESCRIPTION
This is an attempt to partially fix https://github.com/Microsoft/console/issues/23.
To wrap it up:
1. uint[] colorTable -> class ColorScheme.
2. XML scheme parser now reads foreground/background colors.
3. fg/bg color slots are actually designated with wAttributes field in the console info structure.
4. fg/bg color indices are selected based on color similarity -- WIP