### PR TITLE
Feature/powershell compatibility

### DIFF
--- a/tools/ColorTool/ColorTool/Program.cs
+++ b/tools/ColorTool/ColorTool/Program.cs
@@ -257,6 +257,7 @@ namespace ColorTool
                         Version();
                         return;
                     default:
+                        Console.WriteLine("Skipping unsupported parameter: " + arg);
                         break;
                 }
             }

--- a/tools/ColorTool/ColorTool/Program.cs
+++ b/tools/ColorTool/ColorTool/Program.cs
@@ -83,6 +83,7 @@ namespace ColorTool
         static bool quietMode = false;
         static bool setDefaults = false;
         static bool setProperties = true;
+        static bool powershell = false;
 
         static void Usage()
         {
@@ -243,6 +244,10 @@ namespace ColorTool
                         setDefaults = true;
                         setProperties = true;
                         break;
+                    case "-p":
+                    case "--powershell":
+                        powershell = true;
+                        break;
                     case "-?":
                     case "--help":
                         Usage();
@@ -274,6 +279,12 @@ namespace ColorTool
             {
                 Console.WriteLine(string.Format(Resources.SchemeNotFound, schemeName));
                 return;
+            }
+
+            if (powershell)
+            {
+                // PowerShell console windows use the DARK_MAGENTA color slot for the background
+                colorTable[DARK_MAGENTA] = colorTable[DARK_BLACK];
             }
 
             if (setDefaults)

--- a/tools/ColorTool/ColorTool/Resources.resx
+++ b/tools/ColorTool/ColorTool/Resources.resx
@@ -146,12 +146,13 @@ Arguments:
     &lt;schemename&gt;: The name of a color scheme. ct will try to first load it as an .itermcolors color scheme.
                   If that fails, it will look for it as an .ini file color scheme.
 Options:
-    -?, --help     : Display this help message
-    -c, --current  : Print the color table for the currently applied scheme
-    -q, --quiet    : Don't print the color table after applying
-    -d, --defaults : Apply the scheme to only the defaults in the registry
-    -b, --both     : Apply the scheme to both the current console and the defaults.
-    -v, --version  : Display the version number</value>
+    -?, --help       : Display this help message
+    -c, --current    : Print the color table for the currently applied scheme
+    -q, --quiet      : Don't print the color table after applying
+    -d, --defaults   : Apply the scheme to only the defaults in the registry
+    -b, --both       : Apply the scheme to both the current console and the defaults
+    -p, --powershell : Modify the scheme for the PowerShell console
+    -v, --version    : Display the version number</value>
   </data>
   <data name="WroteToDefaults" xml:space="preserve">
     <value>Wrote selected scheme to the defaults.</value>


### PR DESCRIPTION
The PowerShell console doesn't use the DARK_BLACK slot from the colour table for the console background; it uses the DARK_MAGENTA slot instead. 

This PR adds options `-p` and `--powershell` to modify the colour table by copying the value from DARK_BLACK over DARK_MAGENTA so it works for PowerShell windows.

If this isn't done, the background of the PowerShell window has ... *unexpected* effects. Eg `solarized_dark` appears with a magenta background, and `solarized_light` appears with light blue.
