### PR TITLE
Change listing of available schemes to use directory of executable

### DIFF
--- a/tools/ColorTool/ColorTool/Program.cs
+++ b/tools/ColorTool/ColorTool/Program.cs
@@ -189,7 +189,9 @@ namespace ColorTool
 
         static void PrintSchemes()
         {
-            if (Directory.Exists("./schemes"))
+            var schemeDirectory = new FileInfo(new Uri(Assembly.GetEntryAssembly().GetName().CodeBase).AbsolutePath).Directory.FullName + "/schemes"; 
+
+            if (Directory.Exists(schemeDirectory))
             {
                 IntPtr handle = GetStdHandle(-11);
                 GetConsoleMode(handle, out var mode);
@@ -197,7 +199,7 @@ namespace ColorTool
 
                 int consoleWidth = Console.WindowWidth;
                 string fgText = " gYw ";
-                foreach (string schemeName in Directory.GetFiles("./schemes/").Select(Path.GetFileName))
+                foreach (string schemeName in Directory.GetFiles(schemeDirectory).Select(Path.GetFileName))
                 {
                     ColorScheme colorScheme = GetScheme(schemeName, false);
                     if (colorScheme != null)


### PR DESCRIPTION
For use cases where ColorTool has been added to and invoked from PATH, for instance, using a relative path from the working directory to print schemes will result in an empty list. Instead, use the path of the ColorTool.exe to find installed schemes.