### PR TITLE
Consolidate schemes path search code

### DIFF
--- a/tools/ColorTool/ColorTool/IniSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/IniSchemeParser.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Linq;
 using System.Text;
 using System.Runtime.InteropServices;
 using static ColorTool.ConsoleAPI;
@@ -70,41 +71,9 @@ namespace ColorTool
             }
         }
 
-        // TODO: Abstract the locating of a scheme into a function the implementation can call into
-        //      Both parsers duplicate the searching, they should just pass in their extension and
-        //      a callback for initally validating the file
         static string FindIniScheme(string schemeName)
         {
-            string exeDir = System.IO.Directory.GetParent(System.Reflection.Assembly.GetEntryAssembly().Location).FullName;
-            string filename = schemeName + ".ini";
-            string exeSchemes = exeDir + "/schemes/";
-            string cwd = "./";
-            string cwdSchemes = "./schemes/";
-            // Search order, for argument "name", where 'exe' is the dir of the exe.
-            //  1. ./name
-            //  2. ./name.ini
-            //  3. ./schemes/name
-            //  4. ./schemes/name.ini
-            //  5. exe/schemes/name
-            //  6. exe/schemes/name.ini
-            //  7. name (as an absolute path)
-            string[] paths = {
-                cwd + schemeName,
-                cwd + filename,
-                cwdSchemes + schemeName,
-                cwdSchemes + filename,
-                exeSchemes + schemeName,
-                exeSchemes + filename,
-                schemeName,
-            };
-            foreach (string path in paths)
-            {
-                if (File.Exists(path))
-                {
-                    return path;
-                }
-            }
-            return null;
+            return Scheme.GetSearchPaths(schemeName, ".ini").FirstOrDefault(File.Exists);
         }
 
         public ColorScheme ParseScheme(string schemeName, bool reportErrors = true)

--- a/tools/ColorTool/ColorTool/Scheme.cs
+++ b/tools/ColorTool/ColorTool/Scheme.cs
@@ -1,0 +1,41 @@
+﻿//
+//    Copyright (C) Microsoft.  All rights reserved.
+// Licensed under the terms described in the LICENSE file in the root of this project.
+//
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace ColorTool
+{
+    static class Scheme
+    {
+        public static IEnumerable<string> GetSearchPaths(string schemeName, string extension)
+        {
+            // Search order, for argument "name", where 'exe' is the dir of the exe.
+            //  1. ./name
+            //  2. ./name.ext
+            //  3. ./schemes/name
+            //  4. ./schemes/name.ext
+            //  5. exe/schemes/name
+            //  6. exe/schemes/name.ext
+            //  7. name (as an absolute path)
+
+            string cwd = "./";
+            yield return cwd + schemeName;
+
+            string filename = schemeName + extension;
+            yield return cwd + filename;
+
+            string cwdSchemes = "./schemes/";
+            yield return cwdSchemes + schemeName;
+            yield return cwdSchemes + filename;
+
+            string exeDir = Directory.GetParent(System.Reflection.Assembly.GetEntryAssembly().Location).FullName;
+            string exeSchemes = exeDir + "/schemes/";
+            yield return exeSchemes + schemeName;
+            yield return exeSchemes + filename;
+            yield return schemeName;
+        }
+    }
+}

--- a/tools/ColorTool/ColorTool/XmlSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/XmlSchemeParser.cs
@@ -4,6 +4,7 @@
 //
 using System;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Xml;
@@ -81,49 +82,20 @@ namespace ColorTool
         static XmlDocument loadXmlScheme(string schemeName)
         {
             XmlDocument xmlDoc = new XmlDocument(); // Create an XML document object
-            string exeDir = System.IO.Directory.GetParent(System.Reflection.Assembly.GetEntryAssembly().Location).FullName;
-            bool found = false;
-            string filename = schemeName + ".itermcolors";
-            string exeSchemes = exeDir + "/schemes/";
-            string cwd = "./";
-            string cwdSchemes = "./schemes/";
-            // Search order, for argument "name", where 'exe' is the dir of the exe.
-            //  1. ./name
-            //  2. ./name.itermcolors
-            //  3. ./schemes/name
-            //  4. ./schemes/name.itermcolors
-            //  5. exe/schemes/name
-            //  6. exe/schemes/name.itermcolors
-            //  7. name (as an absolute path)
-            string[] paths = {
-                cwd + schemeName,
-                cwd + filename,
-                cwdSchemes + schemeName,
-                cwdSchemes + filename,
-                exeSchemes + schemeName,
-                exeSchemes + filename,
-                schemeName,
-            };
-            foreach (string path in paths)
+            foreach (string path in Scheme.GetSearchPaths(schemeName, ".itermcolors")
+                                          .Where(File.Exists))
             {
                 try
                 {
                     xmlDoc.Load(path);
-                    found = true;
-                    break;
+                    return xmlDoc;
                 }
-                catch (Exception /*e*/)
-                {
-                    // We can either fail to find the file,
-                    //   or fail to parse the XML here.
-                }
+                catch (XmlException /*e*/) { /* failed to parse */ }
+                catch (IOException /*e*/) { /* failed to find */ }
+                catch (UnauthorizedAccessException /*e*/) { /* unauthorized */ }
             }
 
-            if (!found)
-            {
-                return null;
-            }
-            return xmlDoc;
+            return null;
         }
 
 


### PR DESCRIPTION
This PR addresses the following to-do comment in the code by introducing `Scheme.GetSearchPaths` method that is then used from `IniSchemeParser` and `XmlSchemeParser`:

https://github.com/Microsoft/console/blob/f334ba68c94e974d8326f2f39ad89ab739761bd5/tools/ColorTool/ColorTool/IniSchemeParser.cs#L73-L75

