### PR TITLE
Fix UIntTocolor

### DIFF
--- a/tools/ColorTool/ColorTool/Program.cs
+++ b/tools/ColorTool/ColorTool/Program.cs
@@ -230,11 +230,10 @@ namespace ColorTool
 
         private static Color UIntToColor(uint color)
         {
-            byte a = (byte)(color >> 24);
-            byte r = (byte)(color >> 16);
+            byte r = (byte)(color >> 0);
             byte g = (byte)(color >> 8);
-            byte b = (byte)(color >> 0);
-            return Color.FromArgb(a, r, g, b);
+            byte b = (byte)(color >> 16);
+            return Color.FromArgb(r, g, b);
         }
 
         static bool SetProperties(ColorScheme colorScheme)


### PR DESCRIPTION
Fixes UIntToColor to use the same BGR color ordering that the ColorScheme uses, so the -s --schemes output makes sense.