### PR TITLE
Add csharp conpty sample

### DIFF
--- a/samples/ConPTY/MiniTerm/MiniTerm.sln
+++ b/samples/ConPTY/MiniTerm/MiniTerm.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2035
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MiniTerm", "MiniTerm\MiniTerm.csproj", "{121D4818-BD57-433B-8AD5-C4E1ACE7E7C0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{121D4818-BD57-433B-8AD5-C4E1ACE7E7C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{121D4818-BD57-433B-8AD5-C4E1ACE7E7C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{121D4818-BD57-433B-8AD5-C4E1ACE7E7C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{121D4818-BD57-433B-8AD5-C4E1ACE7E7C0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EFB13BDE-C952-4311-9FE7-35EFDAC8F021}
+	EndGlobalSection
+EndGlobal

--- a/samples/ConPTY/MiniTerm/MiniTerm/App.config
+++ b/samples/ConPTY/MiniTerm/MiniTerm/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    </startup>
+</configuration>

--- a/samples/ConPTY/MiniTerm/MiniTerm/MiniTerm.csproj
+++ b/samples/ConPTY/MiniTerm/MiniTerm/MiniTerm.csproj
@@ -45,7 +45,8 @@
     <Compile Include="Native\ConsoleApi.cs" />
     <Compile Include="Native\ProcessApi.cs" />
     <Compile Include="Native\PseudoConsoleApi.cs" />
-    <Compile Include="Process.cs" />
+    <Compile Include="Processes\Process.cs" />
+    <Compile Include="Processes\ProcessFactory.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PseudoConsole.cs" />

--- a/samples/ConPTY/MiniTerm/MiniTerm/MiniTerm.csproj
+++ b/samples/ConPTY/MiniTerm/MiniTerm/MiniTerm.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{121D4818-BD57-433B-8AD5-C4E1ACE7E7C0}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MiniTerm</RootNamespace>
+    <AssemblyName>MiniTerm</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Native\ConsoleApi.cs" />
+    <Compile Include="Native\ProcessApi.cs" />
+    <Compile Include="Native\PseudoConsoleApi.cs" />
+    <Compile Include="Process.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PseudoConsole.cs" />
+    <Compile Include="PseudoConsolePipe.cs" />
+    <Compile Include="Terminal.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/samples/ConPTY/MiniTerm/MiniTerm/Native/ConsoleApi.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/Native/ConsoleApi.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Win32.SafeHandles;
+using System.Runtime.InteropServices;
+
+namespace MiniTerm.Native
+{
+    /// <summary>
+    /// PInvoke signatures for win32 console api
+    /// </summary>
+    static class ConsoleApi
+    {
+        internal const int STD_OUTPUT_HANDLE = -11;
+        internal const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
+        internal const uint DISABLE_NEWLINE_AUTO_RETURN = 0x0008;
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern SafeFileHandle GetStdHandle(int nStdHandle);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool SetConsoleMode(SafeFileHandle hConsoleHandle, uint mode);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool GetConsoleMode(SafeFileHandle handle, out uint mode);
+
+        internal delegate bool ConsoleEventDelegate(CtrlTypes ctrlType);
+
+        internal enum CtrlTypes : uint
+        {
+            CTRL_C_EVENT = 0,
+            CTRL_BREAK_EVENT,
+            CTRL_CLOSE_EVENT,
+            CTRL_LOGOFF_EVENT = 5,
+            CTRL_SHUTDOWN_EVENT
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool SetConsoleCtrlHandler(ConsoleEventDelegate callback, bool add);
+    }
+}

--- a/samples/ConPTY/MiniTerm/MiniTerm/Native/ProcessApi.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/Native/ProcessApi.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace MiniTerm.Native
+{
+    /// <summary>
+    /// PInvoke signatures for win32 process api
+    /// </summary>
+    static class ProcessApi
+    {
+        internal const uint EXTENDED_STARTUPINFO_PRESENT = 0x00080000;
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        internal struct STARTUPINFOEX
+        {
+            public STARTUPINFO StartupInfo;
+            public IntPtr lpAttributeList;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        internal struct STARTUPINFO
+        {
+            public Int32 cb;
+            public string lpReserved;
+            public string lpDesktop;
+            public string lpTitle;
+            public Int32 dwX;
+            public Int32 dwY;
+            public Int32 dwXSize;
+            public Int32 dwYSize;
+            public Int32 dwXCountChars;
+            public Int32 dwYCountChars;
+            public Int32 dwFillAttribute;
+            public Int32 dwFlags;
+            public Int16 wShowWindow;
+            public Int16 cbReserved2;
+            public IntPtr lpReserved2;
+            public IntPtr hStdInput;
+            public IntPtr hStdOutput;
+            public IntPtr hStdError;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct PROCESS_INFORMATION
+        {
+            public IntPtr hProcess;
+            public IntPtr hThread;
+            public int dwProcessId;
+            public int dwThreadId;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SECURITY_ATTRIBUTES
+        {
+            public int nLength;
+            public IntPtr lpSecurityDescriptor;
+            public int bInheritHandle;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool InitializeProcThreadAttributeList(
+            IntPtr lpAttributeList, int dwAttributeCount, int dwFlags, ref IntPtr lpSize);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool UpdateProcThreadAttribute(
+            IntPtr lpAttributeList, uint dwFlags, IntPtr attribute, IntPtr lpValue,
+            IntPtr cbSize, IntPtr lpPreviousValue, IntPtr lpReturnSize);
+
+        [DllImport("kernel32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool CreateProcess(
+            string lpApplicationName, string lpCommandLine, ref SECURITY_ATTRIBUTES lpProcessAttributes,
+            ref SECURITY_ATTRIBUTES lpThreadAttributes, bool bInheritHandles, uint dwCreationFlags,
+            IntPtr lpEnvironment, string lpCurrentDirectory, [In] ref STARTUPINFOEX lpStartupInfo,
+            out PROCESS_INFORMATION lpProcessInformation);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool DeleteProcThreadAttributeList(IntPtr lpAttributeList);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool CloseHandle(IntPtr hObject);
+    }
+}

--- a/samples/ConPTY/MiniTerm/MiniTerm/Native/PseudoConsoleApi.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/Native/PseudoConsoleApi.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+namespace MiniTerm.Native
+{
+    /// <summary>
+    /// PInvoke signatures for win32 pseudo console api
+    /// </summary>
+    static class PseudoConsoleApi
+    {
+        internal const uint PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE = 0x00020016;
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct COORD
+        {
+            public short X;
+            public short Y;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern int CreatePseudoConsole(COORD size, SafeFileHandle hInput, SafeFileHandle hOutput, uint dwFlags, out IntPtr phPC);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern int CreatePseudoConsole(COORD size, IntPtr hInput, IntPtr hOutput, uint dwFlags, out IntPtr phPC);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern int ResizePseudoConsole(IntPtr hPC, COORD size);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern int ClosePseudoConsole(IntPtr hPC);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        internal static extern bool CreatePipe(out SafeFileHandle hReadPipe, out SafeFileHandle hWritePipe, IntPtr lpPipeAttributes, int nSize);
+    }
+}

--- a/samples/ConPTY/MiniTerm/MiniTerm/Native/PseudoConsoleApi.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/Native/PseudoConsoleApi.cs
@@ -22,9 +22,6 @@ namespace MiniTerm.Native
         internal static extern int CreatePseudoConsole(COORD size, SafeFileHandle hInput, SafeFileHandle hOutput, uint dwFlags, out IntPtr phPC);
 
         [DllImport("kernel32.dll", SetLastError = true)]
-        internal static extern int CreatePseudoConsole(COORD size, IntPtr hInput, IntPtr hOutput, uint dwFlags, out IntPtr phPC);
-
-        [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern int ResizePseudoConsole(IntPtr hPC, COORD size);
 
         [DllImport("kernel32.dll", SetLastError = true)]

--- a/samples/ConPTY/MiniTerm/MiniTerm/Process.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/Process.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using static MiniTerm.Native.ProcessApi;
+
+namespace MiniTerm
+{
+    /// <summary>
+    /// Support for starting and configuring processes.
+    /// </summary>
+    /// <remarks>
+    /// Possible to replace with managed code? The key is being able to provide the PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE attribute
+    /// </remarks>
+    static class Process
+    {
+        /// <summary>
+        /// Start and configure a process. The return value should be considered opaque, and eventually disposed.
+        /// </summary>
+        internal static ProcessResources Start(IntPtr hPC, string command, IntPtr attributes)
+        {
+            var startupInfo = ConfigureProcessThread(hPC, attributes);
+            var processInfo = RunProcess(ref startupInfo, "cmd.exe");
+            return new ProcessResources(startupInfo, processInfo);
+        }
+
+        private static STARTUPINFOEX ConfigureProcessThread(IntPtr hPC, IntPtr attributes)
+        {
+            var lpSize = IntPtr.Zero;
+            var success = InitializeProcThreadAttributeList(
+                lpAttributeList: IntPtr.Zero,
+                dwAttributeCount: 1,
+                dwFlags: 0,
+                lpSize: ref lpSize
+            );
+            if (success || lpSize == IntPtr.Zero) // we're not expecting `success` here, we just want to get the calculated lpSize
+            {
+                throw new InvalidOperationException("Could not calculate the number of bytes for the attribute list. " + Marshal.GetLastWin32Error());
+            }
+
+            var startupInfo = new STARTUPINFOEX();
+            startupInfo.StartupInfo.cb = Marshal.SizeOf<STARTUPINFOEX>();
+            startupInfo.lpAttributeList = Marshal.AllocHGlobal(lpSize);
+
+            success = InitializeProcThreadAttributeList(
+                lpAttributeList: startupInfo.lpAttributeList,
+                dwAttributeCount: 1,
+                dwFlags: 0,
+                lpSize: ref lpSize
+            );
+            if (!success)
+            {
+                throw new InvalidOperationException("Could not set up attribute list. " + Marshal.GetLastWin32Error());
+            }
+
+            success = UpdateProcThreadAttribute(
+                lpAttributeList: startupInfo.lpAttributeList,
+                dwFlags: 0,
+                attribute: attributes,
+                lpValue: hPC,
+                cbSize: (IntPtr)IntPtr.Size,
+                lpPreviousValue: IntPtr.Zero,
+                lpReturnSize: IntPtr.Zero
+            );
+            if (!success)
+            {
+                throw new InvalidOperationException("Could not set pseudoconsole thread attribute. " + Marshal.GetLastWin32Error());
+            }
+
+            return startupInfo;
+        }
+
+        private static PROCESS_INFORMATION RunProcess(ref STARTUPINFOEX sInfoEx, string commandLine)
+        {
+            int securityAttributeSize = Marshal.SizeOf<SECURITY_ATTRIBUTES>();
+            var pSec = new SECURITY_ATTRIBUTES { nLength = securityAttributeSize };
+            var tSec = new SECURITY_ATTRIBUTES { nLength = securityAttributeSize };
+            var success = CreateProcess(
+                lpApplicationName: null,
+                lpCommandLine: commandLine,
+                lpProcessAttributes: ref pSec,
+                lpThreadAttributes: ref tSec,
+                bInheritHandles: false,
+                dwCreationFlags: EXTENDED_STARTUPINFO_PRESENT,
+                lpEnvironment: IntPtr.Zero,
+                lpCurrentDirectory: null,
+                lpStartupInfo: ref sInfoEx,
+                lpProcessInformation: out PROCESS_INFORMATION pInfo
+            );
+            if (!success)
+            {
+                throw new InvalidOperationException("Could not create process. " + Marshal.GetLastWin32Error());
+            }
+
+            return pInfo;
+        }
+
+        private static void CleanUp(STARTUPINFOEX startupInfo, PROCESS_INFORMATION processInfo)
+        {
+            // Free the attribute list
+            if (startupInfo.lpAttributeList != IntPtr.Zero)
+            {
+                DeleteProcThreadAttributeList(startupInfo.lpAttributeList);
+                Marshal.FreeHGlobal(startupInfo.lpAttributeList);
+            }
+
+            // Close process and thread handles
+            if (processInfo.hProcess != IntPtr.Zero)
+            {
+                CloseHandle(processInfo.hProcess);
+            }
+            if (processInfo.hThread != IntPtr.Zero)
+            {
+                CloseHandle(processInfo.hThread);
+            }
+        }
+
+        internal sealed class ProcessResources : IDisposable
+        {
+            public ProcessResources(STARTUPINFOEX startupInfo, PROCESS_INFORMATION processInfo)
+            {
+                StartupInfo = startupInfo;
+                ProcessInfo = processInfo;
+            }
+
+            STARTUPINFOEX StartupInfo { get; }
+            PROCESS_INFORMATION ProcessInfo { get; }
+
+            public void Dispose()
+            {
+                CleanUp(StartupInfo, ProcessInfo);
+            }
+        }
+    }
+}

--- a/samples/ConPTY/MiniTerm/MiniTerm/Processes/Process.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/Processes/Process.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using static MiniTerm.Native.ProcessApi;
+
+namespace MiniTerm
+{
+    /// <summary>
+    /// Represents an instance of a process.
+    /// </summary>
+    internal sealed class Process : IDisposable
+    {
+        public Process(STARTUPINFOEX startupInfo, PROCESS_INFORMATION processInfo)
+        {
+            StartupInfo = startupInfo;
+            ProcessInfo = processInfo;
+        }
+
+        public STARTUPINFOEX StartupInfo { get; }
+        public PROCESS_INFORMATION ProcessInfo { get; }
+
+        #region IDisposable Support
+
+        private bool disposedValue = false; // To detect redundant calls
+
+        void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // dispose managed state (managed objects).
+                }
+
+                // dispose unmanaged state
+
+                // Free the attribute list
+                if (StartupInfo.lpAttributeList != IntPtr.Zero)
+                {
+                    DeleteProcThreadAttributeList(StartupInfo.lpAttributeList);
+                    Marshal.FreeHGlobal(StartupInfo.lpAttributeList);
+                }
+
+                // Close process and thread handles
+                if (ProcessInfo.hProcess != IntPtr.Zero)
+                {
+                    CloseHandle(ProcessInfo.hProcess);
+                }
+                if (ProcessInfo.hThread != IntPtr.Zero)
+                {
+                    CloseHandle(ProcessInfo.hThread);
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        ~Process()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(false);
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // use the following line if the finalizer is overridden above.
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+    }
+}

--- a/samples/ConPTY/MiniTerm/MiniTerm/Processes/ProcessFactory.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/Processes/ProcessFactory.cs
@@ -24,6 +24,8 @@ namespace MiniTerm
 
         private static STARTUPINFOEX ConfigureProcessThread(IntPtr hPC, IntPtr attributes)
         {
+            // this method implements the behavior described in https://docs.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session#preparing-for-creation-of-the-child-process
+
             var lpSize = IntPtr.Zero;
             var success = InitializeProcThreadAttributeList(
                 lpAttributeList: IntPtr.Zero,
@@ -92,73 +94,5 @@ namespace MiniTerm
 
             return pInfo;
         }
-    }
-
-    /// <summary>
-    /// Represents an instance of a process
-    /// </summary>
-    internal sealed class Process : IDisposable
-    {
-        public Process(STARTUPINFOEX startupInfo, PROCESS_INFORMATION processInfo)
-        {
-            StartupInfo = startupInfo;
-            ProcessInfo = processInfo;
-        }
-
-        public STARTUPINFOEX StartupInfo { get; }
-        public PROCESS_INFORMATION ProcessInfo { get; }
-
-        #region IDisposable Support
-
-        private bool disposedValue = false; // To detect redundant calls
-
-        void Dispose(bool disposing)
-        {
-            if (!disposedValue)
-            {
-                if (disposing)
-                {
-                    // dispose managed state (managed objects).
-                }
-
-                // dispose unmanaged state
-
-                // Free the attribute list
-                if (StartupInfo.lpAttributeList != IntPtr.Zero)
-                {
-                    DeleteProcThreadAttributeList(StartupInfo.lpAttributeList);
-                    Marshal.FreeHGlobal(StartupInfo.lpAttributeList);
-                }
-
-                // Close process and thread handles
-                if (ProcessInfo.hProcess != IntPtr.Zero)
-                {
-                    CloseHandle(ProcessInfo.hProcess);
-                }
-                if (ProcessInfo.hThread != IntPtr.Zero)
-                {
-                    CloseHandle(ProcessInfo.hThread);
-                }
-
-                disposedValue = true;
-            }
-        }
-
-        ~Process()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(false);
-        }
-
-        // This code added to correctly implement the disposable pattern.
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(true);
-            // use the following line if the finalizer is overridden above.
-            GC.SuppressFinalize(this);
-        }
-
-        #endregion
     }
 }

--- a/samples/ConPTY/MiniTerm/MiniTerm/Program.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/Program.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace MiniTerm
+{
+    /// <summary>
+    /// C# version of:
+    /// https://blogs.msdn.microsoft.com/commandline/2018/08/02/windows-command-line-introducing-the-windows-pseudo-console-conpty/
+    /// https://docs.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session
+    ///
+    /// System Requirements:
+    /// As of September 2018, requires Windows 10 with the "Windows Insider Program" installed for Redstone 5.
+    /// Also requires the Windows Insider Preview SDK: https://www.microsoft.com/en-us/software-download/windowsinsiderpreviewSDK
+    /// </summary>
+    /// <remarks>
+    /// Basic design is:
+    /// Terminal UI starts the PseudoConsole, and controls it using a pair of PseudoConsolePipes
+    /// Terminal UI will run the Process (cmd.exe) and associate it with the PseudoConsole.
+    /// </remarks>
+    static class Program
+    {
+        static void Main(string[] args)
+        {
+            try
+            {
+                var terminal = new Terminal();
+                terminal.Run("cmd.exe");
+            }
+            catch (InvalidOperationException e)
+            {
+                Console.Error.WriteLine(e.Message);
+                throw;
+            }
+        }
+    }
+}

--- a/samples/ConPTY/MiniTerm/MiniTerm/Properties/AssemblyInfo.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MiniPty")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MiniPty")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("121d4818-bd57-433b-8ad5-c4e1ace7e7c0")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/samples/ConPTY/MiniTerm/MiniTerm/PseudoConsole.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/PseudoConsole.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Win32.SafeHandles;
+using System;
+using static MiniTerm.Native.PseudoConsoleApi;
+
+namespace MiniTerm
+{
+    /// <summary>
+    /// Utility functions around the new Pseudo Console APIs
+    /// </summary>
+    internal sealed class PseudoConsole : IDisposable
+    {
+        public static readonly IntPtr PseudoConsoleThreadAttribute = (IntPtr)PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE;
+
+        public IntPtr Handle { get; }
+
+        private PseudoConsole(IntPtr handle)
+        {
+            this.Handle = handle;
+        }
+
+        internal static PseudoConsole Create(SafeFileHandle inputReadSide, SafeFileHandle outputWriteSide, int width, int height)
+        {
+            var createResult = CreatePseudoConsole(
+                new COORD { X = (short)width, Y = (short)height },
+                inputReadSide, outputWriteSide,
+                0, out IntPtr hPC);
+            if(createResult != 0)
+            {
+                throw new InvalidOperationException("Could not create psuedo console. Error Code " + createResult);
+            }
+            return new PseudoConsole(hPC);
+        }
+
+        public void Dispose()
+        {
+            ClosePseudoConsole(Handle);
+        }
+    }
+}

--- a/samples/ConPTY/MiniTerm/MiniTerm/PseudoConsolePipe.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/PseudoConsolePipe.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Win32.SafeHandles;
+using System;
+using static MiniTerm.Native.PseudoConsoleApi;
+
+namespace MiniTerm
+{
+    /// <summary>
+    /// A pipe used to talk to the pseudoconsole, as described in:
+    /// https://docs.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session
+    /// </summary>
+    /// <remarks>
+    /// We'll have two instances of this class, one for input and one for output.
+    /// </remarks>
+    internal sealed class PseudoConsolePipe : IDisposable
+    {
+        public SafeFileHandle ReadSide;
+        public SafeFileHandle WriteSide;
+
+        public PseudoConsolePipe()
+        {
+            if (!CreatePipe(out ReadSide, out WriteSide, IntPtr.Zero, 0))
+            {
+                throw new InvalidOperationException("failed to create pipe");
+            }
+        }
+
+        public void Dispose()
+        {
+            ReadSide.Dispose();
+            WriteSide.Dispose();
+        }
+    }
+}

--- a/samples/ConPTY/MiniTerm/MiniTerm/PseudoConsolePipe.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/PseudoConsolePipe.cs
@@ -24,10 +24,23 @@ namespace MiniTerm
             }
         }
 
+        #region IDisposable
+
+        void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                ReadSide?.Dispose();
+                WriteSide?.Dispose();
+            }
+        }
+
         public void Dispose()
         {
-            ReadSide.Dispose();
-            WriteSide.Dispose();
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
+
+        #endregion
     }
 }

--- a/samples/ConPTY/MiniTerm/MiniTerm/PseudoConsolePipe.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/PseudoConsolePipe.cs
@@ -13,8 +13,8 @@ namespace MiniTerm
     /// </remarks>
     internal sealed class PseudoConsolePipe : IDisposable
     {
-        public SafeFileHandle ReadSide;
-        public SafeFileHandle WriteSide;
+        public readonly SafeFileHandle ReadSide;
+        public readonly SafeFileHandle WriteSide;
 
         public PseudoConsolePipe()
         {

--- a/samples/ConPTY/MiniTerm/MiniTerm/Terminal.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/Terminal.cs
@@ -112,10 +112,10 @@ namespace MiniTerm
         /// <summary>
         /// Get an AutoResetEvent that signals when the process exits
         /// </summary>
-        private static AutoResetEvent WaitForExit(ProcessFactory.Process process) =>
+        private static AutoResetEvent WaitForExit(Process process) =>
             new AutoResetEvent(false)
             {
-                SafeWaitHandle = new SafeWaitHandle(process.ProcessInfo.hProcess, false)
+                SafeWaitHandle = new SafeWaitHandle(process.ProcessInfo.hProcess, ownsHandle: false)
             };
 
         /// <summary>

--- a/samples/ConPTY/MiniTerm/MiniTerm/Terminal.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/Terminal.cs
@@ -1,0 +1,150 @@
+﻿using Microsoft.Win32.SafeHandles;
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using static MiniTerm.Native.ConsoleApi;
+
+namespace MiniTerm
+{
+    /// <summary>
+    /// The UI of the terminal. It's just a normal console window, but we're managing the input/output.
+    /// In a "real" project this could be some other UI.
+    /// </summary>
+    internal sealed class Terminal
+    {
+        private const string ExitCommand = "exit\r";
+        private const string CtrlC_Command = "\x3";
+
+        public Terminal()
+        {
+            EnableVirtualTerminalSequenceProcessing();
+        }
+
+        /// <summary>
+        /// Newer versions of the windows console support interpreting virtual terminal sequences, we just have to opt-in
+        /// </summary>
+        private static void EnableVirtualTerminalSequenceProcessing()
+        {
+            var iStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
+            if (!GetConsoleMode(iStdOut, out uint outConsoleMode))
+            {
+                throw new InvalidOperationException("Could not get console mode");
+            }
+
+            outConsoleMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN;
+            if (!SetConsoleMode(iStdOut, outConsoleMode))
+            {
+                throw new InvalidOperationException("Could not enable virtual terminal processing");
+            }
+        }
+
+        /// <summary>
+        /// Start the psuedoconsole and run the process as shown in 
+        /// https://docs.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session#creating-the-pseudoconsole
+        /// </summary>
+        /// <param name="command">the command to run, e.g. cmd.exe</param>
+        public void Run(string command)
+        {
+            using (var inputPipe = new PseudoConsolePipe())
+            using (var outputPipe = new PseudoConsolePipe())
+            using (var pseudoConsole = PseudoConsole.Create(inputPipe.ReadSide, outputPipe.WriteSide, Console.WindowWidth, Console.WindowHeight))
+            using (var process = Process.Start(pseudoConsole.Handle, command, PseudoConsole.PseudoConsoleThreadAttribute))
+            {
+                // set up a background task to copy all pseudoconsole output to stdout
+                Task.Run(() => CopyPipeToOutput(outputPipe.ReadSide));
+
+                // free resources in case the console is ungracefully closed (e.g. by the 'x' in the window titlebar)
+                OnClose(() => DisposeResources(process, pseudoConsole, outputPipe, inputPipe));
+
+                // prompt for stdin input and send the result to the pipe.
+                // blocks until the user types "exit"
+                CopyInputToPipe(inputPipe.WriteSide);
+            }
+        }
+
+        /// <summary>
+        /// Reads terminal input and copies it to the PseudoConsole
+        /// </summary>
+        /// <param name="inputWriteSide">the "write" side of the pseudo console input pipe</param>
+        private static void CopyInputToPipe(SafeFileHandle inputWriteSide)
+        {
+            using (var writer = new StreamWriter(new FileStream(inputWriteSide, FileAccess.Write)))
+            {
+                ForwardCtrlC(writer);
+                writer.AutoFlush = true;
+                writer.WriteLine(@"cd \");
+
+                StringBuilder buffer = new StringBuilder();
+                while (true)
+                {
+                    // send input character-by-character to the pipe
+                    char key = Console.ReadKey(intercept: true).KeyChar;
+                    writer.Write(key);
+
+                    // stop the input loop if 'exit' was sent
+                    // TODO: if we have nested cmd.exe process, this will kill all of them which is wrong.
+                    // could we somehow detect when the top-level cmd.exe process has ended and remove this logic?
+                    buffer.Append(key);
+                    if (key == '\r')
+                    {
+                        if (buffer.ToString() == ExitCommand)
+                        {
+                            break;
+                        }
+                        buffer.Clear();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Don't let ctrl-c kill the terminal, it should be sent to the process in the terminal.
+        /// </summary>
+        private static void ForwardCtrlC(StreamWriter writer)
+        {
+            Console.CancelKeyPress += (sender, e) =>
+            {
+                e.Cancel = true;
+                writer.Write(CtrlC_Command);
+            };
+        }
+
+        /// <summary>
+        /// Reads PseudoConsole output and copies it to the terminal's standard out.
+        /// </summary>
+        /// <param name="outputReadSide">the "read" side of the pseudo console output pipe</param>
+        private static void CopyPipeToOutput(SafeFileHandle outputReadSide)
+        {
+            using (var terminalOutput = Console.OpenStandardOutput())
+            using (var pseudoConsoleOutput = new FileStream(outputReadSide, FileAccess.Read))
+            {
+                pseudoConsoleOutput.CopyTo(terminalOutput);
+            }
+        }
+
+        /// <summary>
+        /// Set a callback for when the terminal is closed (e.g. via the "X" window decoration button).
+        /// Intended for resource cleanup logic.
+        /// </summary>
+        private static void OnClose(Action handler)
+        {
+            SetConsoleCtrlHandler(eventType =>
+            {
+                if(eventType == CtrlTypes.CTRL_CLOSE_EVENT)
+                {
+                    handler();
+                }
+                return false;
+            }, true);
+        }
+
+        private void DisposeResources(params IDisposable[] disposables)
+        {
+            foreach (var disposable in disposables)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+}

--- a/samples/ConPTY/MiniTerm/MiniTerm/Terminal.cs
+++ b/samples/ConPTY/MiniTerm/MiniTerm/Terminal.cs
@@ -26,14 +26,14 @@ namespace MiniTerm
         /// </summary>
         private static void EnableVirtualTerminalSequenceProcessing()
         {
-            var iStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
-            if (!GetConsoleMode(iStdOut, out uint outConsoleMode))
+            var hStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
+            if (!GetConsoleMode(hStdOut, out uint outConsoleMode))
             {
                 throw new InvalidOperationException("Could not get console mode");
             }
 
             outConsoleMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING | DISABLE_NEWLINE_AUTO_RETURN;
-            if (!SetConsoleMode(iStdOut, outConsoleMode))
+            if (!SetConsoleMode(hStdOut, outConsoleMode))
             {
                 throw new InvalidOperationException("Could not enable virtual terminal processing");
             }
@@ -48,8 +48,8 @@ namespace MiniTerm
         {
             using (var inputPipe = new PseudoConsolePipe())
             using (var outputPipe = new PseudoConsolePipe())
-            using (var pseudoConsole = PseudoConsole.Create(inputPipe.ReadSide, outputPipe.WriteSide, Console.WindowWidth, Console.WindowHeight))
-            using (var process = Process.Start(pseudoConsole.Handle, command, PseudoConsole.PseudoConsoleThreadAttribute))
+            using (var pseudoConsole = PseudoConsole.Create(inputPipe.ReadSide, outputPipe.WriteSide, (short)Console.WindowWidth, (short)Console.WindowHeight))
+            using (var process = Process.Start(command, PseudoConsole.PseudoConsoleThreadAttribute, pseudoConsole.Handle))
             {
                 // set up a background task to copy all pseudoconsole output to stdout
                 Task.Run(() => CopyPipeToOutput(outputPipe.ReadSide));

--- a/samples/ConPTY/MiniTerm/README.md
+++ b/samples/ConPTY/MiniTerm/README.md
@@ -1,0 +1,19 @@
+# MiniTerm
+
+Experimental terminal using the new PTY APIs from Microsoft. Written in C#, and heavily based on the native code examples.
+
+## Status
+
+Demonstrates the basic API calls required, but not intended for "real-world" usage.
+
+## Resources
+
+- [Introductory blog post from Microsoft](https://blogs.msdn.microsoft.com/commandline/2018/08/02/windows-command-line-introducing-the-windows-pseudo-console-conpty/)
+- [MSDN Documentation](https://docs.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session)
+
+## System Requirements
+
+See the Introductory blog post from Microsoft for the full setup instructions. This project has been tested with:
+
+- OS: Windows 10 Pro Build 17744
+- SDK: Windows_InsiderPreview_SDK_en-us_17749


### PR DESCRIPTION
As I mentioned in https://github.com/Microsoft/console/issues/251, I've been working on a basic C# terminal that uses the new PseudoConsole APIs. It's at a point where I've fixed all the known bugs, and I think it could be a useful sample in this repo.

The demo is similar to the existing EchoCon example in that it uses the virtual terminal processing feature, starts up a pseudoconsole, and runs a command. It also handles ctrl-c and window exit.

I'd appreciate some advice on ways to improve it as I'm fairly inexperienced when it comes to writing terminals and pinvoking Windows APIs. The following areas might need some attention:

- [x] ~Handling when the user types `exit`. Right now it exits the terminal, when the user might just want to exit whatever the currently running process is. There's a TODO marking that area.~ Completed this, now we wait for the top-level process to exit.
- [ ] I've used the .NET SafeFileHandle class in place of some of the IntPtrs normally found in PInvoke signatures. I'm not sure what the best practice is here.

I've split this PR into three commits, the final commit will be the most interesting to review.

I've tested this with the following versions:

- OS: Windows 10 Pro Build 17744
- SDK: Windows_InsiderPreview_SDK_en-us_17749

Thanks!