### PR TITLE
Wrap file system export write in try/catch.

### DIFF
--- a/tools/ColorTool/ColorTool/Program.cs
+++ b/tools/ColorTool/ColorTool/Program.cs
@@ -433,20 +433,28 @@ namespace ColorTool
             bool success = GetConsoleScreenBufferInfoEx(hOut, ref csbiex);
             if (success)
             {
-                using (System.IO.StreamWriter file = new System.IO.StreamWriter(outputPath))
+                try
                 {
-                    file.WriteLine("[table]");
-                    for (int i = 0; i < 16; i++)
+                    // StreamWriter can fail for a variety of file system reasons so catch exceptions and print message.
+                    using (System.IO.StreamWriter file = new System.IO.StreamWriter(outputPath))
                     {
-                        string line = IniSchemeParser.COLOR_NAMES[i];
-                        line += " = ";
-                        uint color = csbiex.ColorTable[i];
-                        uint r = color & (0x000000ff);
-                        uint g = (color & (0x0000ff00)) >> 8;
-                        uint b = (color & (0x00ff0000)) >> 16;
-                        line += r + "," + g + "," + b;
-                        file.WriteLine(line);
+                        file.WriteLine("[table]");
+                        for (int i = 0; i < 16; i++)
+                        {
+                            string line = IniSchemeParser.COLOR_NAMES[i];
+                            line += " = ";
+                            uint color = csbiex.ColorTable[i];
+                            uint r = color & (0x000000ff);
+                            uint g = (color & (0x0000ff00)) >> 8;
+                            uint b = (color & (0x00ff0000)) >> 16;
+                            line += r + "," + g + "," + b;
+                            file.WriteLine(line);
+                        }
                     }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex.Message);
                 }
             }
             else


### PR DESCRIPTION
@adiviness tried writing on a non-writeable network share and got a nice stack exception dump off the top. 

As such, I'll wrap this with a try/catch and print the error message when the StreamWriter fails. He got an access denied, but I can think of a good dozen reasons this would fail. A catch all should be fine for now.

Also the string should be pre-localized.