### PR TITLE
Add signing configuration information to repository.

### DIFF
--- a/tools/ColorTool/signing/CopySignFiles.cmd
+++ b/tools/ColorTool/signing/CopySignFiles.cmd
@@ -1,0 +1,37 @@
+REM @echo off
+REM This script copies the files to have different paths to be signed and copies them back
+
+if "%2" == "" goto :usage
+if "%1" == "sign" goto :sign
+if "%1" == "afterSign" goto :afterSign
+
+goto :usage
+
+:sign
+pushd "%2"
+mkdir tosign
+call :checkedCopy ..\b\Release\anycpu\ColorTool.exe tosign\ColorTool.exe
+
+popd
+goto :end
+
+:afterSign
+pushd "%2"
+call :checkedCopy signed\ColorTool.exe ..\b\Release\anycpu\ColorTool.exe
+
+popd
+goto :end
+
+:checkedCopy
+copy %1 %2
+if %errorlevel% NEQ 0 (
+    popd
+    exit 1
+)
+exit /b
+
+:usage
+echo "Usage: CopySignFiles <sign| afterSign> <root of the repo>"
+echo "Will copy the binary release from <root>\Release to be sent to signed"
+
+:end

--- a/tools/ColorTool/signing/SignConfig.xml
+++ b/tools/ColorTool/signing/SignConfig.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<SignConfigXML>
+  <job platform="anycpu" configuration="release" dest="__RELBINPATH__\..\..\..\s\signed" jobname="Console ColorTool" approvers="miniksa;migrie;duhowett">
+    <file src="__RELBINPATH__\..\..\..\s\tosign\colortool.exe" signType="Authenticode" dest="__RELBINPATH__\..\..\..\s\signed\colortool.exe" />
+  </job>
+</SignConfigXML>

--- a/tools/ColorTool/signing/SignConfig.xml
+++ b/tools/ColorTool/signing/SignConfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <SignConfigXML>
-  <job platform="anycpu" configuration="release" dest="__RELBINPATH__\..\..\..\s\signed" jobname="Console ColorTool" approvers="miniksa;migrie;duhowett">
+  <job platform="anycpu" configuration="release" dest="__RELBINPATH__\..\..\..\s\signed" jobname="Console ColorTool" approvers="miniksa;migrie;duhowett;austdi">
     <file src="__RELBINPATH__\..\..\..\s\tosign\colortool.exe" signType="Authenticode" dest="__RELBINPATH__\..\..\..\s\signed\colortool.exe" />
   </job>
 </SignConfigXML>


### PR DESCRIPTION
We need the signing configuration for color tool when it runs through the build system to come from the Git repository instead of from another ancillary, non-source-controlled place. 