### PR TITLE
Don't report scheme parse errors by default

### DIFF
--- a/tools/ColorTool/ColorTool/ISchemeParser.cs
+++ b/tools/ColorTool/ColorTool/ISchemeParser.cs
@@ -9,6 +9,6 @@ namespace ColorTool
     {
         string Name { get; }
 
-        ColorScheme ParseScheme(string schemeName, bool reportErrors = true);
+        ColorScheme ParseScheme(string schemeName, bool reportErrors = false);
     }
 }

--- a/tools/ColorTool/ColorTool/IniSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/IniSchemeParser.cs
@@ -76,7 +76,7 @@ namespace ColorTool
             return Scheme.GetSearchPaths(schemeName, ".ini").FirstOrDefault(File.Exists);
         }
 
-        public ColorScheme ParseScheme(string schemeName, bool reportErrors = true)
+        public ColorScheme ParseScheme(string schemeName, bool reportErrors = false)
         {
             bool success = true;
 

--- a/tools/ColorTool/ColorTool/JsonParser.cs
+++ b/tools/ColorTool/ColorTool/JsonParser.cs
@@ -60,7 +60,7 @@ namespace ColorTool
             return null;
         }
 
-        public ColorScheme ParseScheme(string schemeName, bool reportErrors = true)
+        public ColorScheme ParseScheme(string schemeName, bool reportErrors = false)
         {
             XmlDocument xmlDoc = loadJsonFile(schemeName);
             if (xmlDoc == null) return null;

--- a/tools/ColorTool/ColorTool/Program.cs
+++ b/tools/ColorTool/ColorTool/Program.cs
@@ -106,6 +106,7 @@ namespace ColorTool
         };
 
         static bool quietMode = false;
+        static bool reportErrors = false;
         static bool setDefaults = false;
         static bool setProperties = true;
         static bool setUnixStyle = false;
@@ -480,6 +481,10 @@ namespace ColorTool
                     case "--current":
                         PrintTable();
                         return;
+                    case "-e":
+                    case "--errors":
+                        reportErrors = true;
+                        break;
                     case "-q":
                     case "--quiet":
                         quietMode = true;
@@ -529,7 +534,7 @@ namespace ColorTool
 
             string schemeName = args[args.Length - 1];
 
-            ColorScheme colorScheme = GetScheme(schemeName);
+            ColorScheme colorScheme = GetScheme(schemeName, reportErrors);
 
             if (colorScheme == null)
             {
@@ -561,7 +566,7 @@ namespace ColorTool
                 .Select(t => (ISchemeParser)Activator.CreateInstance(t));
         }
                 
-        private static ColorScheme GetScheme(string schemeName, bool reportErrors = true)
+        private static ColorScheme GetScheme(string schemeName, bool reportErrors = false)
         {
             foreach (var parser in GetParsers())
             {

--- a/tools/ColorTool/ColorTool/Resources.resx
+++ b/tools/ColorTool/ColorTool/Resources.resx
@@ -141,17 +141,19 @@
     <value>Usage:
     colortool.exe [options] &lt;schemename&gt;
 ColorTool is a utility for helping to set the color palette of the Windows Console.
-By default, applies the colors in the specified .itermcolors or .ini file to the current console window.
+By default, applies the colors in the specified .itermcolors, .json or .ini file to the current console window.
 This does NOT save the properties automatically. For that, you'll need to open the properties sheet and hit "Ok".
 Included should be a `schemes/` directory with a selection of schemes of both formats for examples.
 Feel free to add your own preferred scheme to that directory.
 Arguments:
-    &lt;schemename&gt;: The name of a color scheme. ct will try to first load it as an .itermcolors color scheme.
-                  If that fails, it will look for it as an .ini file color scheme.
+    &lt;schemename&gt;: The name of a color scheme. ct will try to first load it as an .ini file color scheme
+                  If that fails, it will look for it as a .json file color scheme
+                  If that fails, it will look for it as an .itermcolors file color scheme.
 Options:
     -?, --help     : Display this help message
     -c, --current  : Print the color table for the currently applied scheme
     -q, --quiet    : Don't print the color table after applying
+    -e, --errors   : Report scheme parsing errors on the console
     -d, --defaults : Apply the scheme to only the defaults in the registry
     -b, --both     : Apply the scheme to both the current console and the defaults.
     -x, --xterm    : Set the colors using VT sequences. Used for setting the colors in WSL.

--- a/tools/ColorTool/ColorTool/XmlSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/XmlSchemeParser.cs
@@ -99,7 +99,7 @@ namespace ColorTool
         }
 
 
-        public ColorScheme ParseScheme(string schemeName, bool reportErrors = true)
+        public ColorScheme ParseScheme(string schemeName, bool reportErrors = false)
         {
             XmlDocument xmlDoc = loadXmlScheme(schemeName); // Create an XML document object
             if (xmlDoc == null) return null;


### PR DESCRIPTION
ColorTool now has three different color scheme parsers (.ini files, [concfg](https://github.com/lukesampson/concfg/tree/master/presets) JSON files and [itermcolors](https://iterm2colorschemes.com/) XML files). Because each scheme parser is tried in turn until one succeeds, any scheme parser that fails dumps useless error information to the console.

This change flips the `reportErrors` parameter of `ISchemeParser.ParseScheme` from true to false so these failed parse error messages are not printed by default. This PR also adds a new `--errors` or `-e` command line argument to enable error reporting for usage scenarios that need it.