### PR TITLE
Back and forground index export

### DIFF
--- a/tools/ColorTool/ColorTool/ColorScheme.cs
+++ b/tools/ColorTool/ColorTool/ColorScheme.cs
@@ -14,6 +14,9 @@ namespace ColorTool
         public uint? foreground = null;
         public uint? background = null;
 
+        public uint? popupForeground = null;
+        public uint? popupBackground = null;
+
         public int CalculateIndex(uint value) =>
             colorTable.Select((color, idx) => Tuple.Create(color, idx))
                       .OrderBy(Difference(value))

--- a/tools/ColorTool/ColorTool/ColorScheme.cs
+++ b/tools/ColorTool/ColorTool/ColorScheme.cs
@@ -11,11 +11,8 @@ namespace ColorTool
     public class ColorScheme
     {
         public uint[] colorTable = null;
-        public uint? foreground = null;
-        public uint? background = null;
+        public ConsoleAttributes consoleAttributes;
 
-        public uint? popupForeground = null;
-        public uint? popupBackground = null;
 
         public int CalculateIndex(uint value) =>
             colorTable.Select((color, idx) => Tuple.Create(color, idx))
@@ -83,14 +80,14 @@ namespace ColorTool
                 _dump($"Color[{i}]", colorTable[i]);
             }
 
-            if (foreground != null)
+            if (consoleAttributes.foreground != null)
             {
-                _dump("FG       ", foreground.Value);
+                _dump("FG       ", consoleAttributes.foreground.Value);
             }
 
-            if (background != null)
+            if (consoleAttributes.background != null)
             {
-                _dump("BG       ", background.Value);
+                _dump("BG       ", consoleAttributes.background.Value);
             }
         }
     }

--- a/tools/ColorTool/ColorTool/ConsoleAttributes.cs
+++ b/tools/ColorTool/ColorTool/ConsoleAttributes.cs
@@ -1,0 +1,17 @@
+﻿//
+//    Copyright (C) Microsoft.  All rights reserved.
+// Licensed under the terms described in the LICENSE file in the root of this project.
+//
+
+namespace ColorTool
+{
+    public struct ConsoleAttributes
+    {
+        public uint? foreground;
+        public uint? background;
+
+        public uint? popupForeground;
+        public uint? popupBackground;
+
+    }
+}

--- a/tools/ColorTool/ColorTool/IniSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/IniSchemeParser.cs
@@ -123,16 +123,22 @@ namespace ColorTool
                     {
                         var forgroundIndex = (COLOR_NAMES as IList<string>).IndexOf(forground);
                         var backgroundIndex = (COLOR_NAMES as IList<string>).IndexOf(background);
-                        popupForgroundColor = colorTable[forgroundIndex];
-                        popupBackgroundColor = colorTable[backgroundIndex];
+                        if (forgroundIndex != -1 && backgroundIndex != -1)
+                        {
+                            popupForgroundColor = colorTable[forgroundIndex];
+                            popupBackgroundColor = colorTable[backgroundIndex];
+                        }
                     }
 
                     if (ReadAttributes("screen", out forground, out background))
                     {
                         var forgroundIndex = (COLOR_NAMES as IList<string>).IndexOf(forground);
                         var backgroundIndex = (COLOR_NAMES as IList<string>).IndexOf(background);
-                        forgroundColor = colorTable[forgroundIndex];
-                        backgroundColor = colorTable[backgroundIndex];
+                        if (forgroundIndex != -1 && backgroundIndex != -1)
+                        {
+                            forgroundColor = colorTable[forgroundIndex];
+                            backgroundColor = colorTable[backgroundIndex];
+                        }
                     }
                 }
                 catch (Exception /*e*/)

--- a/tools/ColorTool/ColorTool/IniSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/IniSchemeParser.cs
@@ -154,7 +154,8 @@ namespace ColorTool
 
             if (colorTable != null)
             {
-                return new ColorScheme { colorTable = colorTable, consoleAttributes = new ConsoleAttributes { background = backgroundColor, foreground = foregroundColor, popupBackground = popupBackgroundColor, popupForeground = popupForegroundColor } };
+                var consoleAttributes = new ConsoleAttributes { background = backgroundColor, foreground = foregroundColor, popupBackground = popupBackgroundColor, popupForeground = popupForegroundColor };
+                return new ColorScheme { colorTable = colorTable, consoleAttributes = consoleAttributes };
             }
             else
             {

--- a/tools/ColorTool/ColorTool/IniSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/IniSchemeParser.cs
@@ -86,9 +86,9 @@ namespace ColorTool
 
             string[] tableStrings = new string[COLOR_TABLE_SIZE];
             uint[] colorTable = null;
-            uint? forgroundColor = null;
+            uint? foregroundColor = null;
             uint? backgroundColor = null;
-            uint? popupForgroundColor = null;
+            uint? popupForegroundColor = null;
             uint? popupBackgroundColor = null;
 
             for (int i = 0; i < COLOR_TABLE_SIZE; i++)
@@ -119,24 +119,24 @@ namespace ColorTool
                         colorTable[i] = ParseColor(tableStrings[i]);
                     }
 
-                    if (ReadAttributes("popup", out var forground, out var background))
+                    if (ReadAttributes("popup", out var foreground, out var background))
                     {
-                        var forgroundIndex = (COLOR_NAMES as IList<string>).IndexOf(forground);
+                        var foregroundIndex = (COLOR_NAMES as IList<string>).IndexOf(foreground);
                         var backgroundIndex = (COLOR_NAMES as IList<string>).IndexOf(background);
-                        if (forgroundIndex != -1 && backgroundIndex != -1)
+                        if (foregroundIndex != -1 && backgroundIndex != -1)
                         {
-                            popupForgroundColor = colorTable[forgroundIndex];
+                            popupForegroundColor = colorTable[foregroundIndex];
                             popupBackgroundColor = colorTable[backgroundIndex];
                         }
                     }
 
-                    if (ReadAttributes("screen", out forground, out background))
+                    if (ReadAttributes("screen", out foreground, out background))
                     {
-                        var forgroundIndex = (COLOR_NAMES as IList<string>).IndexOf(forground);
+                        var foregroundIndex = (COLOR_NAMES as IList<string>).IndexOf(foreground);
                         var backgroundIndex = (COLOR_NAMES as IList<string>).IndexOf(background);
-                        if (forgroundIndex != -1 && backgroundIndex != -1)
+                        if (foregroundIndex != -1 && backgroundIndex != -1)
                         {
-                            forgroundColor = colorTable[forgroundIndex];
+                            foregroundColor = colorTable[foregroundIndex];
                             backgroundColor = colorTable[backgroundIndex];
                         }
                     }
@@ -154,22 +154,22 @@ namespace ColorTool
 
             if (colorTable != null)
             {
-                return new ColorScheme { colorTable = colorTable, background = backgroundColor, foreground = forgroundColor, popupBackground = popupBackgroundColor, popupForeground = popupForgroundColor };
+                return new ColorScheme { colorTable = colorTable, background = backgroundColor, foreground = foregroundColor, popupBackground = popupBackgroundColor, popupForeground = popupForegroundColor };
             }
             else
             {
                 return null;
             }
 
-            bool ReadAttributes(string section, out string forground, out string background)
+            bool ReadAttributes(string section, out string foreground, out string background)
             {
-                forground = null;
+                foreground = null;
                 background = null;
 
                 StringBuilder buffer = new StringBuilder(512);
                 GetPrivateProfileString(section, "FOREGROUND", null, buffer, 512, filename);
-                forground = buffer.ToString();
-                if (!COLOR_NAMES.Contains(forground))
+                foreground = buffer.ToString();
+                if (!COLOR_NAMES.Contains(foreground))
                     return false;
 
 

--- a/tools/ColorTool/ColorTool/IniSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/IniSchemeParser.cs
@@ -154,7 +154,7 @@ namespace ColorTool
 
             if (colorTable != null)
             {
-                return new ColorScheme { colorTable = colorTable, background = backgroundColor, foreground = foregroundColor, popupBackground = popupBackgroundColor, popupForeground = popupForegroundColor };
+                return new ColorScheme { colorTable = colorTable, consoleAttributes = new ConsoleAttributes { background = backgroundColor, foreground = foregroundColor, popupBackground = popupBackgroundColor, popupForeground = popupForegroundColor } };
             }
             else
             {

--- a/tools/ColorTool/ColorTool/JsonParser.cs
+++ b/tools/ColorTool/ColorTool/JsonParser.cs
@@ -77,6 +77,26 @@ namespace ColorTool
                     colorTable[i] = ParseColor(node.InnerText);
                 }
 
+
+                uint? popupForeground = null;
+                uint? popupBackground = null;
+
+                var popupNode = children.OfType<XmlNode>().Where(n => n.Name == "popup_colors").SingleOrDefault();
+                if (popupNode != null)
+                {
+                    var parts = popupNode.InnerText.Split(',');
+                    if (parts.Length == 2)
+                    {
+                        var foregroundIndex = (CONCFG_COLOR_NAMES as IList<string>).IndexOf(parts[0]);
+                        var backgroundIndex = (CONCFG_COLOR_NAMES as IList<string>).IndexOf(parts[1]);
+                        if (foregroundIndex != -1 && backgroundIndex != -1)
+                        {
+                            popupForeground = colorTable[foregroundIndex];
+                            popupBackground = colorTable[backgroundIndex];
+                        }
+                    }
+                }
+
                 uint? screenForeground = null;
                 uint? screenBackground = null;
 
@@ -96,7 +116,7 @@ namespace ColorTool
                     }
                 }
 
-                return new ColorScheme { colorTable = colorTable, background = screenBackground, foreground = screenForeground };
+                return new ColorScheme { colorTable = colorTable, background = screenBackground, foreground = screenForeground, popupBackground = popupBackground, popupForeground = popupForeground };
             }
             catch (Exception /*e*/)
             {

--- a/tools/ColorTool/ColorTool/JsonParser.cs
+++ b/tools/ColorTool/ColorTool/JsonParser.cs
@@ -116,7 +116,8 @@ namespace ColorTool
                     }
                 }
 
-                return new ColorScheme { colorTable = colorTable, consoleAttributes = new ConsoleAttributes { background = screenBackground, foreground = screenForeground, popupBackground = popupBackground, popupForeground = popupForeground } };
+                var consoleAttributes = new ConsoleAttributes { background = screenBackground, foreground = screenForeground, popupBackground = popupBackground, popupForeground = popupForeground };
+                return new ColorScheme { colorTable = colorTable, consoleAttributes = consoleAttributes };
             }
             catch (Exception /*e*/)
             {

--- a/tools/ColorTool/ColorTool/JsonParser.cs
+++ b/tools/ColorTool/ColorTool/JsonParser.cs
@@ -116,7 +116,7 @@ namespace ColorTool
                     }
                 }
 
-                return new ColorScheme { colorTable = colorTable, background = screenBackground, foreground = screenForeground, popupBackground = popupBackground, popupForeground = popupForeground };
+                return new ColorScheme { colorTable = colorTable, consoleAttributes = new ConsoleAttributes { background = screenBackground, foreground = screenForeground, popupBackground = popupBackground, popupForeground = popupForeground } };
             }
             catch (Exception /*e*/)
             {

--- a/tools/ColorTool/ColorTool/Program.cs
+++ b/tools/ColorTool/ColorTool/Program.cs
@@ -370,16 +370,16 @@ namespace ColorTool
                 {
                     csbiex.ColorTable[i] = colorScheme.colorTable[i];
                 }
-                if (colorScheme.background != null && colorScheme.foreground != null)
+                if (colorScheme.consoleAttributes.background != null && colorScheme.consoleAttributes.foreground != null)
                 {
-                    int fgidx = colorScheme.CalculateIndex(colorScheme.foreground.Value);
-                    int bgidx = colorScheme.CalculateIndex(colorScheme.background.Value);
+                    int fgidx = colorScheme.CalculateIndex(colorScheme.consoleAttributes.foreground.Value);
+                    int bgidx = colorScheme.CalculateIndex(colorScheme.consoleAttributes.background.Value);
                     csbiex.wAttributes = (ushort)(fgidx | (bgidx << 4));
                 }
-                if (colorScheme.popupBackground != null && colorScheme.popupForeground != null)
+                if (colorScheme.consoleAttributes.popupBackground != null && colorScheme.consoleAttributes.popupForeground != null)
                 {
-                    int fgidx = colorScheme.CalculateIndex(colorScheme.popupForeground.Value);
-                    int bgidx = colorScheme.CalculateIndex(colorScheme.popupBackground.Value);
+                    int fgidx = colorScheme.CalculateIndex(colorScheme.consoleAttributes.popupForeground.Value);
+                    int bgidx = colorScheme.CalculateIndex(colorScheme.consoleAttributes.popupBackground.Value);
                     csbiex.wPopupAttributes = (ushort)(fgidx | (bgidx << 4));
                 }
                 SetConsoleScreenBufferInfoEx(hOut, ref csbiex);

--- a/tools/ColorTool/ColorTool/Program.cs
+++ b/tools/ColorTool/ColorTool/Program.cs
@@ -370,11 +370,17 @@ namespace ColorTool
                 {
                     csbiex.ColorTable[i] = colorScheme.colorTable[i];
                 }
-                if(colorScheme.background != null && colorScheme.foreground != null)
+                if (colorScheme.background != null && colorScheme.foreground != null)
                 {
                     int fgidx = colorScheme.CalculateIndex(colorScheme.foreground.Value);
                     int bgidx = colorScheme.CalculateIndex(colorScheme.background.Value);
                     csbiex.wAttributes = (ushort)(fgidx | (bgidx << 4));
+                }
+                if (colorScheme.popupBackground != null && colorScheme.popupForeground != null)
+                {
+                    int fgidx = colorScheme.CalculateIndex(colorScheme.popupForeground.Value);
+                    int bgidx = colorScheme.CalculateIndex(colorScheme.popupBackground.Value);
+                    csbiex.wPopupAttributes = (ushort)(fgidx | (bgidx << 4));
                 }
                 SetConsoleScreenBufferInfoEx(hOut, ref csbiex);
             }

--- a/tools/ColorTool/ColorTool/Program.cs
+++ b/tools/ColorTool/ColorTool/Program.cs
@@ -206,7 +206,7 @@ namespace ColorTool
             Console.ForegroundColor = currentForeground;
             Console.BackgroundColor = currentBackground;
         }
-        
+
         static void PrintTableWithVt()
         {
             // Save the current background and foreground colors.
@@ -242,7 +242,7 @@ namespace ColorTool
                 "46m",
                 "47m"
             };
-            
+
             Console.Write("\t");
             for (int bg = 0; bg < BGs.Length; bg++)
             {
@@ -283,7 +283,7 @@ namespace ColorTool
                     }
                     else
                     {
-                        Console.Write("\x1b[" +BGs[bg]);
+                        Console.Write("\x1b[" + BGs[bg]);
                     }
 
                     Console.Write(test);
@@ -463,6 +463,20 @@ namespace ColorTool
                             line += r + "," + g + "," + b;
                             file.WriteLine(line);
                         }
+
+                        file.WriteLine();
+                        file.WriteLine("[screen]");
+                        var forgroundIndex = csbiex.wAttributes & 0xF;
+                        var backgroundIndex = csbiex.wAttributes >> 4;
+                        file.WriteLine($"FOREGROUND = {IniSchemeParser.COLOR_NAMES[forgroundIndex]}");
+                        file.WriteLine($"BACKGROUND = {IniSchemeParser.COLOR_NAMES[backgroundIndex]}");
+
+                        file.WriteLine();
+                        file.WriteLine("[popup]");
+                        forgroundIndex = csbiex.wPopupAttributes & 0xF;
+                        backgroundIndex = csbiex.wPopupAttributes >> 4;
+                        file.WriteLine($"FOREGROUND = {IniSchemeParser.COLOR_NAMES[forgroundIndex]}");
+                        file.WriteLine($"BACKGROUND = {IniSchemeParser.COLOR_NAMES[backgroundIndex]}");
                     }
                 }
                 catch (Exception ex)
@@ -530,7 +544,7 @@ namespace ColorTool
                         break;
                     case "-o":
                     case "--output":
-                        if (i+1 < args.Length)
+                        if (i + 1 < args.Length)
                         {
                             ExportCurrentAsIni(args[i + 1]);
                         }
@@ -581,7 +595,7 @@ namespace ColorTool
                 .Where(t => !t.IsAbstract && typeof(ISchemeParser).IsAssignableFrom(t))
                 .Select(t => (ISchemeParser)Activator.CreateInstance(t));
         }
-                
+
         private static ColorScheme GetScheme(string schemeName, bool reportErrors = false)
         {
             foreach (var parser in GetParsers())
@@ -593,6 +607,6 @@ namespace ColorTool
                 }
             }
             return null;
-       }
+        }
     }
 }

--- a/tools/ColorTool/ColorTool/XmlSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/XmlSchemeParser.cs
@@ -135,7 +135,8 @@ namespace ColorTool
                 return null;
             }
 
-            return new ColorScheme { colorTable = colorTable, consoleAttributes = new ConsoleAttributes { foreground = fgColor, background = bgColor } };
+            var consoleAttributes = new ConsoleAttributes { foreground = fgColor, background = bgColor };
+            return new ColorScheme { colorTable = colorTable, consoleAttributes = consoleAttributes };
         }
     }
 }

--- a/tools/ColorTool/ColorTool/XmlSchemeParser.cs
+++ b/tools/ColorTool/ColorTool/XmlSchemeParser.cs
@@ -135,7 +135,7 @@ namespace ColorTool
                 return null;
             }
 
-            return new ColorScheme { colorTable = colorTable, foreground = fgColor, background = bgColor };
+            return new ColorScheme { colorTable = colorTable, consoleAttributes = new ConsoleAttributes { foreground = fgColor, background = bgColor } };
         }
     }
 }


### PR DESCRIPTION
This is an proposal to store background and foreground color index.

I've added two section `screen` and `popup`. Both sections contain two keys `FORGROUND` and `BACKGROUND`. The assignable values are keys of the `table` section.

**sample**
```ini
[table]
DARK_BLACK = 12,12,12
DARK_BLUE = 0,55,218
DARK_GREEN = 19,161,14
DARK_CYAN = 58,150,221
DARK_RED = 197,15,31
DARK_MAGENTA = 1,36,86
DARK_YELLOW = 238,237,240
DARK_WHITE = 204,204,204
BRIGHT_BLACK = 118,118,118
BRIGHT_BLUE = 59,120,255
BRIGHT_GREEN = 22,198,12
BRIGHT_CYAN = 97,214,214
BRIGHT_RED = 231,72,86
BRIGHT_MAGENTA = 180,0,158
BRIGHT_YELLOW = 249,241,165
BRIGHT_WHITE = 242,242,242

[screen]
FOREGROUND = DARK_YELLOW
BACKGROUND = DARK_MAGENTA

[popup]
FOREGROUND = DARK_CYAN
BACKGROUND = BRIGHT_WHITE

[info]
name = powershell-default
```